### PR TITLE
Add map component

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,2 @@
+# Create a copy of this file called `.env` in the root of the project
+REACT_APP_MAPBOX_TOKEN=<your_mapbox_token>

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.env

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -1,0 +1,83 @@
+import * as React from "react"
+import { useState, useMemo } from "react"
+import Map, {
+  Marker,
+  Popup,
+  NavigationControl,
+  FullscreenControl,
+  ScaleControl,
+  GeolocateControl,
+} from "react-map-gl"
+
+import Pin from "./pin"
+
+// locally you can set this in the .env file, which is ignored by git (so you can keep your secrets secret)
+// on vercel you can set these in the environment variables
+const TOKEN = process.env.REACT_APP_MAPBOX_TOKEN
+
+const locations = [
+  { Title: "test", geolocation: { lat: -34.9341, lng: 117.3611 } },
+]
+
+export default function App() {
+  const [popupInfo, setPopupInfo] = useState(null)
+
+  const pins = useMemo(
+    () =>
+      locations.map((location, index) => (
+        <Marker
+          key={`marker-${index}`}
+          longitude={location.geolocation.lng}
+          latitude={location.geolocation.lat}
+          anchor="bottom"
+          onClick={(e) => {
+            // If we let the click event propagates to the map, it will immediately close the popup
+            // with `closeOnClick: true`
+            e.originalEvent.stopPropagation()
+            setPopupInfo(location)
+          }}
+        >
+          <Pin />
+        </Marker>
+      )),
+    []
+  )
+
+  return (
+    <>
+      <link
+        href="https://api.mapbox.com/mapbox-gl-js/v2.6.1/mapbox-gl.css"
+        rel="stylesheet"
+      />
+      <Map
+        initialViewState={{
+          latitude: -34.9341,
+          longitude: 117.3611,
+          zoom: 3.5,
+          bearing: 0,
+          pitch: 0,
+        }}
+        mapStyle="mapbox://styles/mapbox/dark-v9"
+        mapboxAccessToken={TOKEN}
+      >
+        <GeolocateControl position="top-left" />
+        <FullscreenControl position="top-left" />
+        <NavigationControl position="top-left" />
+        <ScaleControl />
+
+        {pins}
+
+        {popupInfo && (
+          <Popup
+            anchor="top"
+            longitude={Number(popupInfo.geolocation.lng)}
+            latitude={Number(popupInfo.geolocation.lat)}
+            onClose={() => setPopupInfo(null)}
+          >
+            <div>{popupInfo.Title}</div>
+          </Popup>
+        )}
+      </Map>
+    </>
+  )
+}

--- a/src/Map/pin.js
+++ b/src/Map/pin.js
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+const ICON = `M20.2,15.7L20.2,15.7c1.1-1.6,1.8-3.6,1.8-5.7c0-5.6-4.5-10-10-10S2,4.5,2,10c0,2,0.6,3.9,1.6,5.4c0,0.1,0.1,0.2,0.2,0.3
+  c0,0,0.1,0.1,0.1,0.2c0.2,0.3,0.4,0.6,0.7,0.9c2.6,3.1,7.4,7.6,7.4,7.6s4.8-4.5,7.4-7.5c0.2-0.3,0.5-0.6,0.7-0.9
+  C20.1,15.8,20.2,15.8,20.2,15.7z`;
+
+const pinStyle = {
+  cursor: 'pointer',
+  fill: '#d00',
+  stroke: 'none'
+};
+
+function Pin({size = 20}) {
+  return (
+    <svg height={size} viewBox="0 0 24 24" style={pinStyle}>
+      <path d={ICON} />
+    </svg>
+  );
+}
+
+export default React.memo(Pin);


### PR DESCRIPTION
This PR adds the mapbox component.

This doesn't add libs:
`yarn add react-map-gl mapbox-gl`

or implement the map:

`import Map from "./Map"`

```
<div style={{ width: "100vw", height: "100vh" }}>
        <Map />
      </div>
```

