### PR TITLE
Add pan to site button on the cards

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,45 +1,45 @@
-import * as React from 'react';
-import Drawer from '@mui/material/Drawer';
-import Toolbar from '@mui/material/Toolbar';
+import * as React from "react"
+import Drawer from "@mui/material/Drawer"
+import Toolbar from "@mui/material/Toolbar"
 // import locations from './locations.json'
-import videos from './videos.json'
-import DrawerCard from './DrawerCard';
-import { useRef } from 'react';
-import GeoMap from './Map';
-import { useState } from 'react';
+import videos from "./videos.json"
+import DrawerCard from "./DrawerCard"
+import GeoMap from "./Map"
+import { useState } from "react"
+import { MapProvider } from "react-map-gl"
 
-
-
-const drawerWidth = 400;
+const drawerWidth = 400
 
 export default function LocationDrawer() {
   const [popupInfo, setPopupInfo] = useState(null)
-
   return (
-      <>
-      <div style={{height:"100vh"}}>
-        <GeoMap popupInfo={popupInfo} setPopupInfo={setPopupInfo} videos={videos}/>
+    <MapProvider>
+      <div style={{ height: "100vh" }}>
+        <GeoMap
+          popupInfo={popupInfo}
+          setPopupInfo={setPopupInfo}
+          videos={videos}
+        />
       </div>
       <Drawer
         sx={{
           width: drawerWidth,
           flexShrink: 0,
-          '& .MuiDrawer-paper': {
+          "& .MuiDrawer-paper": {
             width: drawerWidth,
-            boxSizing: 'border-box',
+            boxSizing: "border-box",
           },
         }}
         variant="permanent"
         anchor="right"
       >
-
         <Toolbar />
-          <div align="center">
-            {videos.map((location, index) => (
-              <DrawerCard key={index} location={location} />
+        <div align="center">
+          {videos.map((location, index) => (
+            <DrawerCard key={index} location={location} />
           ))}
-          </div>
+        </div>
       </Drawer>
-      </>
-  );
+    </MapProvider>
+  )
 }

--- a/src/DrawerCard.js
+++ b/src/DrawerCard.js
@@ -1,36 +1,52 @@
-import * as React from 'react';
-import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
-import CardContent from '@mui/material/CardContent';
-import CardMedia from '@mui/material/CardMedia';
-import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
-import { Box } from '@mui/material';
+import * as React from "react"
+import Card from "@mui/material/Card"
+import CardActions from "@mui/material/CardActions"
+import CardContent from "@mui/material/CardContent"
+import CardMedia from "@mui/material/CardMedia"
+import Button from "@mui/material/Button"
+import Typography from "@mui/material/Typography"
+import { Box } from "@mui/material"
+import { useMap } from "react-map-gl"
 
+export default function DrawerCard({ location }) {
+  const { denmarkMap } = useMap()
+  const onClick = () => {
+    denmarkMap.flyTo({
+      center: [location.geolocation.lng, location.geolocation.lat],
+    })
+  }
 
-export default function DrawerCard({location} )  {
-    console.log(location)
   return (
     <Box pt={2} pb={2}>
-        <Card sx={{ maxWidth: 345 }}>
-        <iframe width="320" height="180" src={location.youtube_url} title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      <Card sx={{ maxWidth: 345 }}>
+        <iframe
+          width="320"
+          height="180"
+          src={location.youtube_url}
+          title="YouTube video player"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+        ></iframe>
         {/* <CardMedia
             sx={{ height: 140 }}
             image="{locations.Title}"
             title="location"
         /> */}
         <CardContent>
-            <Typography gutterBottom variant="h5" component="div">
-                {location.name}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-                {location.description}
-            </Typography>
+          <Typography gutterBottom variant="h5" component="div">
+            {location.name}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {location.description}
+          </Typography>
         </CardContent>
-        {/* <CardActions>
-            <Button size="small">Learn More</Button>
-        </CardActions> */}
-        </Card>
+        <CardActions>
+          <Button size="small" onClick={onClick}>
+            Fly to site
+          </Button>
+        </CardActions>
+      </Card>
     </Box>
-  );
+  )
 }

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -44,6 +44,7 @@ export default function GeoMap({ popupInfo, setPopupInfo, videos }) {
         rel="stylesheet"
       />
       <Map
+        id="denmarkMap"
         initialViewState={{
           latitude: -34.9341,
           longitude: 117.3611,


### PR DESCRIPTION
This adds a card action to pan to the relevant site on the map.

Adds the MapsProvider at the top level so that we can share map contexts about where the map is implemented (i.e. so we can access it in the drawer cards)

Uses the `useMap` hook in the card to access the map object.

adds a flyTo handler when the card is clicked.